### PR TITLE
Touch ups on the ModuleMappingPage

### DIFF
--- a/src/components/MappingPage.vue
+++ b/src/components/MappingPage.vue
@@ -32,7 +32,7 @@
         </li>
       </ul>
     </div>
-    <div class="module-tile-container" v-for="moduleTile in filteredModuleTiles" :key="moduleTile.university">
+    <div class="module-tile-container" v-for="moduleTile in filteredandSortedModuleTiles" :key="moduleTile.university">
       <ModuleTile
         :university="moduleTile.university"
         :local-modules-count="moduleTile.localModules.length"
@@ -218,12 +218,14 @@ export default {
     })
   },
   computed: {
-    filteredModuleTiles() {
+    filteredandSortedModuleTiles() {
+     let filteredModuleTiles = [];
       if (this.getActiveContinent() === 'All') {
-        return this.universityData;
+        filteredModuleTiles = this.universityData;
       } else {
-        return this.universityData.filter((university) => university.continent === this.getActiveContinent());
+        filteredModuleTiles = this.universityData.filter((university) => university.continent === this.getActiveContinent());
       }
+      return filteredModuleTiles.sort((a, b) => b.localModules.length - a.localModules.length);
     }
   },
     methods: {

--- a/src/components/MappingPage.vue
+++ b/src/components/MappingPage.vue
@@ -32,7 +32,8 @@
         </li>
       </ul>
     </div>
-    <div class="module-tile-container" v-for="moduleTile in filteredandSortedModuleTiles" :key="moduleTile.university">
+    <div class="module-tile-container" v-if="filteredandSortedModuleTiles.length > 0">
+      <div v-for="moduleTile in filteredandSortedModuleTiles" :key="moduleTile.university">
       <ModuleTile
         :university="moduleTile.university"
         :local-modules-count="moduleTile.localModules.length"
@@ -44,6 +45,12 @@
         :module-sets="moduleTile.moduleSets"
       />
     </div>
+  </div>
+  <div v-else class="text-center" >
+    <br>
+    <p>No mappable universities. Try keying in more modules.</p>
+    <br>
+  </div>
   </div>
 </template>
 

--- a/src/components/MappingPage.vue
+++ b/src/components/MappingPage.vue
@@ -261,6 +261,7 @@ export default {
       for (const mod of this.inputs) { // Getting the input NUS Modules
         const nusModRef = doc(db, "NUS Module Mapping", mod)
         const modSnap = await getDoc(nusModRef)
+        if (modSnap.exists()) {  
         const nusModTitle = modSnap.data()
         console.log(nusModTitle.ModuleTitle)
 
@@ -282,6 +283,10 @@ export default {
             addToPartnerModules["partnerName"] = PUModTitle
             universityModHash[uni][mod]["partnerModules"].push(addToPartnerModules)
           })
+        }
+        } else {
+          console.log(`Module code "${mod}" not found in database.`)
+          window.alert(`Module code "${mod}" not found in database.`)
         }
       }
 

--- a/src/components/MappingPage.vue
+++ b/src/components/MappingPage.vue
@@ -48,7 +48,7 @@
   </div>
   <div v-else class="text-center" >
     <br>
-    <p>No mappable universities. Try keying in more modules.</p>
+    <p>No mappable universities. Try keying in more / different modules.</p>
     <br>
   </div>
   </div>

--- a/src/components/ModuleTile.vue
+++ b/src/components/ModuleTile.vue
@@ -1,5 +1,9 @@
 <template>
   <div class="module-tile">
+    <router-link
+      :to="`/university/` + university"
+      style="text-decoration: none; color: var(--primary)"
+    >
     <div class="module-tile-header">
       <div class="university">{{ university }}</div>
       <div class="local-modules-count">{{ localModulesCount }} </div>
@@ -20,6 +24,7 @@
         </div>
       </div>
     </div>
+    </router-link>
   </div>
 </template>
 


### PR DESCRIPTION
- Arranged the ModuleTiles to be displayed in descending order of module counts.
- Users will now be directed to the relevant Individual University Page when they click on the ModuleTile
- Added text to be displayed when there is no university that matches their filter condition
- Fixed error where no moduleTiles will be displayed when user enters a module code that is not present in our database